### PR TITLE
Remove unused API 100 ProGuard rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,14 +1,7 @@
 # Xposed
 -adaptresourcefilecontents META-INF/xposed/java_init.list
--keepattributes RuntimeVisibleAnnotations
 -keep,allowobfuscation,allowoptimization public class * extends io.github.libxposed.api.XposedModule {
-    public <init>(...);
-    public void onPackageLoaded(...);
-    public void onSystemServerLoaded(...);
-}
--keep,allowoptimization,allowobfuscation @io.github.libxposed.api.annotations.* class * {
-    @io.github.libxposed.api.annotations.BeforeInvocation <methods>;
-    @io.github.libxposed.api.annotations.AfterInvocation <methods>;
+    public <init>();
 }
 
 # Kotlin


### PR DESCRIPTION
Noticed these ProGuard rules are left over from the annotation API (added in 5149df4) and do nothing on API 101: the `annotations` package is gone, and `onSystemServerLoaded` is now `onSystemServerStarting`. Lifecycle callbacks override library methods, so they need no keep rules either.

Narrowing `<init>(...)` to `<init>()` is safe beyond this example too: since API 101 the framework constructs entry classes only through the no-arg constructor.

Minified release build is identical before and after (same APK, same mapping). Loads fine in LSPosed scoped to Settings.

Could address #16. The per-callback keeps suggested there shouldn't be needed, since R8 keeps overrides of library methods on a kept class. Happy to spell them out instead if you'd rather the example be explicit.